### PR TITLE
[radarchart] improve passing index to each entry

### DIFF
--- a/src/radarchart/mapping.js
+++ b/src/radarchart/mapping.js
@@ -14,14 +14,12 @@ export const mapData = function (data, mapping, dataTypes, dimensions) {
   // we will use rollup to populate a flat array of objects
   // that will be passed to the render
   let results = []
-  let index = 0
 
   const result = d3.rollups(
     data,
     (v) => {
-      //@TODO: find a better way to assing a unique index to each entry
       return v.map((d) => {
-        mapping.axes.value.forEach((axisName) => {
+        mapping.axes.value.forEach((axisName, index) => {
           let item = {
             name: index, // each line will create a radar
             color: d[mapping.color.value],
@@ -32,9 +30,7 @@ export const mapData = function (data, mapping, dataTypes, dimensions) {
 
           results.push(item)
         })
-
-        index++
-
+        
         return 'done'
       })
     },


### PR DESCRIPTION
Solves [this comment](https://github.com/rawgraphs/rawgraphs-charts/pull/84/files#diff-a5b85d712bd3d990a03a45ffe9a7b0fefd05e99cc3192ebb2e5dfbb6ae17b574L22) by using second parameter in anonymous function as index in the chart mapping.