### PR TITLE
Fix voronoi category

### DIFF
--- a/src/voronoidiagram/metadata.js
+++ b/src/voronoidiagram/metadata.js
@@ -6,7 +6,7 @@ export const metadata = {
   id: 'rawgraphs.voronoidiagram',
   thumbnail,
   icon,
-  categories: ['Correlations'],
+  categories: ['correlations'],
   description:
     'It creates the minimum area around each point defined by two variables. When applied to a scatterplot, it is useful to show the distance between points.',
   code: 'https://github.com/rawgraphs/rawgraphs-charts/tree/master/src/voronoidiagram',


### PR DESCRIPTION
The model voronoi had "Correlations" with capital initial, causing the dropdown menu of templates categories to have two "correlations" elements because in other models is spelled in small case. The fix should solve the interface problem.